### PR TITLE
Hotfix/parse

### DIFF
--- a/include/HTTP/RequestHeader.hpp
+++ b/include/HTTP/RequestHeader.hpp
@@ -11,7 +11,6 @@ class RequestHeader : public Header
 {
  public:
   RequestHeader();
-  RequestHeader(const std::string &data);
   RequestHeader(const RequestHeader &origin);
   ~RequestHeader();
 
@@ -28,6 +27,8 @@ class RequestHeader : public Header
 
   wsv_header_t&   GetItem(const std::string &key);
   req_header_it_t FindItem(const std::string &key);
+
+  void  Parse(const std::string &data);
 
   void  Print();
   void  PrintRequestLine();

--- a/src/HTTP/RequestHeader.cpp
+++ b/src/HTTP/RequestHeader.cpp
@@ -2,13 +2,6 @@
 
 RequestHeader::RequestHeader() : pos_(0) {}
 
-RequestHeader::RequestHeader(const std::string &data) : pos_(0)
-{
-  ParseRequestLine(data);
-  ParseHeaderLine(data);
-  ParseBodyLine(data);
-}
-
 RequestHeader::RequestHeader(const RequestHeader &origin)
 {
   *this = origin;
@@ -112,7 +105,12 @@ wsv_header_t& RequestHeader::GetItem(const std::string &key)
   }
   return *(it->second);
 }
-
+void  RequestHeader::Parse(const std::string &data)
+{
+  ParseRequestLine(data);
+  ParseHeaderLine(data);
+  ParseBodyLine(data);
+}
 // TODO return 에서 throw ParseError()로 바꾸기
 int RequestHeader::ParseRequestLine(const std::string &data)
 {

--- a/src/core/Client.cpp
+++ b/src/core/Client.cpp
@@ -64,7 +64,8 @@ FdInterfaceType Client::ParseHeader(std::string &request_message)
 {
   std::string tmp = request_message.substr(request_message.find(CRLF) + 4);
   request_message = request_message.substr(0, request_message.find(CRLF));
-  request = new RequestHeader(request_message);
+  request = new RequestHeader();
+  request->Parse(request_message);
   request_message = tmp;
 
   int status = CheckRequest();

--- a/test/test_request_class.cpp
+++ b/test/test_request_class.cpp
@@ -6,7 +6,8 @@ int main()
   const std::string dummy = "GET /tutorials/other/top-20-mysql-best-practices/ HTTP/1.1\r\nHost: code.tutsplus.com\r\nUser-Agent: Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)\r\nAccept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r\nAccept-Language: en-us,en;q=0.5\r\nAccept-Encoding: gzip,deflate\r\nAccept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7\r\nKeep-Alive: 300\r\nConnection: keep-alive\r\nCookie: PHPSESSID=r2t5uvjq435r4q7ib3vtdjq120\r\nPragma: no-cache\r\nCache-Control: no-cache\r\n\r\n";
 
   { // constructor with string
-    RequestHeader requestHeader(dummy);
+    RequestHeader requestHeader;
+    requestHeader.Parse(dummy);
     if (dummy.length() == requestHeader.ToString().length()) {
       std::cout << "TRUE" << std::endl;
     }
@@ -60,7 +61,8 @@ int main()
     }
   }
   {
-    RequestHeader requestHeader(dummy);
+    RequestHeader requestHeader;
+    requestHeader.Parse(dummy);
 
     const std::string dummy1 = "5\r\nhello\r\n\r\n";
     const std::string dummy2 = "5\r\nworld\r\n\r\n";
@@ -90,7 +92,8 @@ int main()
       "PATH_INFO=../",
       "CONTENT_LENGTH=5"
     };
-    RequestHeader requestHeader(dummy);
+    RequestHeader requestHeader;
+    requestHeader.Parse(dummy);
     requestHeader.SetItem("Content-Length", "5");
     requestHeader.SetBody("Hello");
     char ** ret = requestHeader.ToCgi(CGI_PHP);
@@ -103,12 +106,10 @@ int main()
     const std::string dummy1 = "GET /html/default.html HTTP/1.1\r\nHost: 127.0.0.1:8176\r\nConnection: keep-alive\r\nCache-Control: max-age=0\r\nsec-ch-ua: \" Not A;Brand\";v=\"99\", \"Chromium\";v=\"100\", \"Whale\";v=\"3\"\r\nsec-ch-ua-mobile: ?0\r\nsec-ch-ua-platform: \"macOS\"\r\nUpgrade-Insecure-Requests: 1\r\nUser-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.151 Whale/3.14.134.62 Safari/537.36\r\nAccept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9\r\nSec-Fetch-Site: none\r\nSec-Fetch-Mode: navigate\r\nSec-Fetch-User: ?1\r\nSec-Fetch-Dest: document\r\nAccept-Encoding: gzip, deflate, br\r\nAccept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7\r\n\r\n";
     const std::string dummy2 = "GET /html/index.html HTTP/1.1\r\n\r\n";
 
-    RequestHeader requestHeader1(dummy1);
-    RequestHeader requestHeader2(dummy2);
-    RequestHeader *h1 = new RequestHeader(dummy2);
-    RequestHeader *h2 = new RequestHeader(dummy2);
-    (void)h1;
-    (void)h2;
+    RequestHeader requestHeader1;
+    requestHeader1.Parse(dummy1);
+    RequestHeader requestHeader2;
+    requestHeader2.Parse(dummy2);
   }
   return 0;
 }


### PR DESCRIPTION
# Feature
request단일라인 파싱에서 RequestHeader생성자로 생성시 에러나는 문제 수정

ParseRequestLine() 호출 후, 
ParseHeaderLine() 호출시에 바로 CRLF 나오는 처리 필요