### PR TITLE
Fix: Cgi response if문 삭제, test.config 수정

### DIFF
--- a/src/core/Cgi.cpp
+++ b/src/core/Cgi.cpp
@@ -61,8 +61,8 @@ int Cgi::EventReadToCgi()
     return n;
   buf[n] = '\0';
   cgi_read_data += buf;
-  if (request->body.size() <= cgi_read_data.size())
-    return 0;
+  // if (request->body.size() <= cgi_read_data.size())
+  //   return 0;
 
   return n;
 }

--- a/test.config
+++ b/test.config
@@ -20,7 +20,7 @@ server {
 	location /post_body {
 		error_page ./html/404.html;
 		allow_methods POST;
-		root ./test_dir/;
+		root ./test_dir/post_body;
 		index index.html index2.html;
 		auto_index on;
 		cgi_info .bla ./cgi_tester;


### PR DESCRIPTION
Cgi.cpp 에서 cgi response 받는 부분에 if 문때문에 헤더 길이보다 짧은 body 가 아예 안받아지는 문제때문에
```
 if (request->body.size() <= cgi_read_data.size())
    return 0;
```
if 문 일단 주석으로 삭제했습니다!
테스터도 잘 통과하는거 확인했습니다.

+) test.config에서 post_body 부분 수정했습니다